### PR TITLE
Remove vets-json-schema as a peer dependency

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,12 +10,11 @@ If you are starting a completely new application from scratch, the easiest way t
 
 If you are installing the library into an existing application, you can follow these steps:
 
-1. Install the library: 
+1. Install the library:
 `npm install --save https://github.com/usds/us-forms-system.git`
 
 2. Install peer dependencies:
 - `npm install --save-dev @department-of-veterans-affairs/formation`
-- `npm install --save-dev https://github.com/department-of-veterans-affairs/vets-json-schema.git`
 - `npm install --save-dev uswds@^1.6.3`
 - `npm install --save-dev react@^15.5.4`
 - `npm install --save-dev react-dom@^15.6.2`

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "@department-of-veterans-affairs/formation": "^0.8.0",
     "react": "^15.5.4",
     "react-dom": "^15.6.2",
-    "vets-json-schema": "*",
     "uswds": "^1.6.3"
   },
   "dependencies": {


### PR DESCRIPTION
## Description

vets-json-schema is used in the unit tests and already referenced as a devDependency. However, it as also listed as a peerDependency which is not necessary since consumers of this package aren't required to install it.

I get one "Pending" unit test,

>     - should fill in other formData when a suggestion is selected

Also this message:

> Warning: Failed prop type: The prop `onValueChange` is marked as required in `ErrorableCheckbox`, but its value is `undefined`.

These occur in master already though so I don't think they're related.

Before you hit Submit, make sure you’ve done whichever of these applies to you:

- [x] Run `npm test` and make sure the tests for the files you have changed have passed.

