### PR TITLE
Fix unit test messages

### DIFF
--- a/src/js/review/SubmitController.jsx
+++ b/src/js/review/SubmitController.jsx
@@ -90,7 +90,7 @@ class SubmitController extends React.Component {
         <p><strong>Note:</strong> According to federal law, there are criminal penalties, including a fine and/or imprisonment for up to 5 years, for withholding information or for providing incorrect information. (See 18 U.S.C. 1001)</p>
         <PrivacyAgreement
           required
-          onChange={this.props.setPrivacyAgreement}
+          onChange={setPrivacyAgreement}
           checked={privacyAgreementAccepted}
           showError={showPrivacyAgreementError}/>
         <SubmitButtons

--- a/test/js/fields/AutosuggestField.unit.spec.jsx
+++ b/test/js/fields/AutosuggestField.unit.spec.jsx
@@ -422,6 +422,4 @@ describe('<AutosuggestField>', () => {
     });
   });
 
-
-  it.skip('should fill in other formData when a suggestion is selected', () => {});
 });


### PR DESCRIPTION
Eliminates warning message in unit tests

Partial fix for #84

- [x] Run `npm test` and make sure the tests for the files you have changed have passed.

