### PR TITLE
Add npm publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,13 @@
 version: 2
-jobs:
-  build:
+
+common: &common
     docker:
       - image: circleci/node:8.11.3-browsers
-    working_directory: ~/us-forms-system
+    working_directory: ~/repo
+
+jobs:
+  build:
+    <<: *common
     steps:
       - checkout # to working_directory
       - run: 'sudo npm install -g npm@6'
@@ -16,4 +20,31 @@ jobs:
             - ./node_modules
       - run: npm run lint
       - run: npm test
-      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples
+      - persist_to_workspace:
+          root: ~/repo
+          paths: .
+
+  deploy:
+    <<: *common
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
+      - run: npm publish
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build:   # run for all branches and PRs
+          filters:
+            tags:
+              only: /v.*/
+      - deploy: # run for only tagged (master)
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,4 +42,4 @@ workflows:
             - build
           filters:
             branches:
-              only: master
+              only: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,17 +34,12 @@ jobs:
 
 workflows:
   version: 2
-  build-deploy:
+  build_and_deploy:
     jobs:
-      - build:   # run for all branches and PRs
-          filters:
-            tags:
-              only: /v.*/
-      - deploy: # run for only tagged (master)
+      - build
+      - deploy:
           requires:
             - build
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              ignore: /.*/
+              only: master


### PR DESCRIPTION
According to [this blog post](https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/), this will do what we want. I've tried testing on my local repo but it's super difficult and error-prone to do that so I'm going to put this up on the real repo. 

Note that the repo is currently on 1.0.0. Once we start publishing to npm we should follow semver which means we are likely to be increasing the major version relatively frequently if we make breaking changes, which seems inevitable in the near term. There is no problem with that but sometimes people see version numbers as a sign of library maturity (e.g., *"It's at version 5.1.3 so it must have been around for a while."*)

Once I've ensured this is all working properly I'll write up instructions for publishing. It's a bit tricky since we can't push directly to master because the tagged commit is in the PR and **must** land without being rebased/squashed and it should be at the head of master at the point where it's landed. 

