### PR TITLE
Add docs for creating a simple form

### DIFF
--- a/docs/building-a-form/creating-a-form-config-file.md
+++ b/docs/building-a-form/creating-a-form-config-file.md
@@ -4,10 +4,62 @@ Your form is generated from a JSON Schema configuration file called `form.js`, a
 
 ### In this guide
 
+- [Building a simple form](#building a simple form)
 - [Example `form.js` file](#example-form.js-file)
 - [About the `schema` and `uiSchema` objects](#about-the-schema-and-uischema-objects)
 - [Configuring `uiSchema` using rjsf options](#configuring-uischema-using-rjsf-options)
 - [Configuring `uiSchema` using US Form System options](#configuring-uischema-using-us-form-system-options)
+
+### Building a simple form
+
+The US Forms System contains a `FormApp` component that you configure and control via a `formConfig` object. In the starter app, the file that exports this object is located in `/src/js/config/form.js` and included in `/src/components/Form.jsx`. where `FormApp`is used. When building an app from scratch you can define and include these components where it's convenient.
+
+The `formConfig` has several sections, that include, for example:
+* A `title` of the form;
+* A set of `chapters` and `pages` that group form fields for display on the screen;
+* A `uiSchema` with instructions about the way form elements should be displayed and labelled;
+* A `schema` with information about the data resulting from the elements once they have been filled;
+* Optional `introduction` and `confirmation` pages that can appear before and after the form.
+
+The remainder of this page has much more detail about these and other options.
+
+Here is a simple form that requests a name, phone number, and email address:
+
+```js
+import Introduction from '../components/Introduction.jsx';
+
+const formConfig = {
+  title: "Simple form",
+  introduction: Introduction,
+  chapters: {
+    onlyChapter: {
+      title: "Contact Information",
+      pages: {
+        onlyPage: {
+          path: "contact-info",
+          title: "",
+          schema: {
+            type: "object",
+            required: [ "name", "phone", "email" ],
+            properties: {
+              name: { type: "string" },
+              phone: { type: "string" },
+              email: { type: "string" }
+            }
+          },
+          uiSchema: {
+            name: { "ui:title": "Name" },
+            phone: { "ui:title": "Phone" },
+            email: { "ui:title": "Email" }
+          }
+        }
+      }
+    }
+  }
+};
+```
+
+There are several enhancements that can (and should!) be made to this form. For example, there is no validation or formatting of the data, although the `required` property of the `schema` at least ensures that fields are not totally empty. However, it does demonstrate the basics.
 
 ### Example `form.js` file
 

--- a/docs/building-a-form/creating-a-form-config-file.md
+++ b/docs/building-a-form/creating-a-form-config-file.md
@@ -12,7 +12,11 @@ Your form is generated from a JSON Schema configuration file called `form.js`, a
 
 ### Building a simple form
 
-The US Forms System contains a `FormApp` component that you configure and control via a `formConfig` object. In the starter app, the file that exports this object is located in `/src/js/config/form.js` and included in `/src/components/Form.jsx`. where `FormApp`is used. When building an app from scratch you can define and include these components where it's convenient.
+To build a form, you'll use the configuration file to specify everything your form needs: questions, how questions are grouped together, content on the page, data validation, etc. In [the starter app](https://github.com/usds/us-forms-system-starter-app), the file that exports this configuration object is located at `/src/js/config/form.js` and defines a `formConfig`.
+
+Most of the time you'll just be working within the config file to describe the form you need and you won't be writing React components. However, there are two cases that require working with React components directly:
+1. **Rendering the top-level React component**: US Forms System uses a top-level React component, `FormApp`, to pass the `formConfig` object to the other components that are rendered. For the React component hierarchy to properly render, you must include `FormApp` in _your_ app's top-level component and pass it the `formConfig` object as a prop. If you're using the [starter app](https://github.com/usds/us-forms-system-starter-app), it already [takes care of this](https://github.com/usds/us-forms-system-starter-app/blob/master/js/components/Form.jsx).
+2. **Creating custom components**: There may be times where you'll want to create your own custom React components to include in the form config. Examples may include creating a custom page you want to render (e.g., an introduction page), creating a component for content (e.g., a warning message) you want to render within a page, or creating a new component to override one of our default ones. In these cases you'll be building React components from scratch.
 
 The `formConfig` has several sections, that include, for example:
 * A `title` of the form;


### PR DESCRIPTION
I'm not totally comfortable with this because it seems pretty extensive for a "simple" form. In particular:

* If you leave the `introduction` page out the browser crashes with a "too much recursion" error so it's not really optional. It seems like there's some issue with it redirecting to `/introduction` which doesn't exist. I expected that if the intro was not specified it would go directly to the first page of the form. I wonder if `confirmation` is also crash-inducing since we haven't gotten to it in the starter app.

* Even for a simple one-page form you end up having to create wrapper chapters and pages. I'm also not sure if review should be required on a simple one-page form. It's super easy to make mistakes when creating a deeply nested `formConfig` from scratch and get nonsensical errors because it looks like `formConfig` isn't checked against a JSON Schema itself. If you miss a level of nesting on something it really confuses the code.

* There is a `schema` `title` and a `uiSchema` `ui:title`, it isn't clear to me when to use either although I used the `uiSchema` ones here so I'd have *something* in that object. However, it seems like using `schema` `title` would be a *lot* less typing and redundancy for this case. There's a [similarly confused person](https://github.com/mozilla-services/react-jsonschema-form/issues/957) who made a ticket in react-jsonschema-form. This particular case makes me think it would be super handy to have the code create a default title from the name of the field, e.g. `email` becomes `Email`.

* The `page` `title` seems like it could be optional but the React component says that it is not. The React component throws a warning in the console based on `propTypes` defined.

* The `chapter` `title` isn't required (no warnings) but has to be specified in practice. If it's not, the review page will show an empty untitled box in the accordion. Most likely we should require it, unless the review page can also be optional (if so, I don't know how yet). 

* When you get to the review page, the review component throws a `propTypes` warning because the `trackingPrefix` is not specified, this is related to the undocumented functionality mentioned in #134. I don't think we want to make Google Analytics a requirement.

I suspect this will need some changes, either to the text here in the PR, the code, or both. Fire away!