### PR TITLE
Add Markdown template for release notes

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,0 +1,34 @@
+# Release Notes Template
+
+Use this template to create release notes for new US Forms System releases. See https://github.com/usds/us-forms-system/releases/tag/v1.1.0 for an example.
+
+```
+# X.X.X Release
+
+Thank you for using the US Forms System library. For questions about this release, [open an issue](https://github.com/usds/us-forms-system/issues/new/choose).
+
+## Breaking Changes
+
+This release includes breaking changes that you should consider before updating. <Outline breaking changes either inline or in bullets under this paragraph.>
+
+## New Features
+
+<Document improvements to the library here. Bug fixes go below.>
+
+- **Brief description** <Elaborate if necessary here, otherwise delete.> Outlined in <issue link>, addressed in <pull request link>.
+- **Brief description** <Elaborate if necessary here, otherwise delete.> Outlined in <issue link>, addressed in <pull request link>.
+- **Brief description** <Elaborate if necessary here, otherwise delete.> Outlined in <issue link>, addressed in <pull request link>.
+
+## Resolved Security Issues
+
+- **Brief description** <Give more information about the security issue here, including a link to a CVE if one exists.> Fixed in <pull request link>.
+
+## Bug Fixes
+
+<Bug fixes are changes that remedy undesirable or broken functionality.>
+
+- **Brief description** <Elaborate if necessary here, otherwise delete.> Reported in <issue link>, fixed in <pull request link>.
+- **Brief description** <Elaborate if necessary here, otherwise delete.> Reported in <issue link>, fixed in <pull request link>.
+- **Brief description** <Elaborate if necessary here, otherwise delete.> Reported in <issue link>, fixed in <pull request link>.
+
+```

--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -31,4 +31,12 @@ This release includes breaking changes that you should consider before updating.
 - **Brief description** <Elaborate if necessary here, otherwise delete.> Reported in <issue link>, fixed in <pull request link>.
 - **Brief description** <Elaborate if necessary here, otherwise delete.> Reported in <issue link>, fixed in <pull request link>.
 
+## Thanks
+
+Thank you to the following people for contributing to this release:
+
+- [@username](https://github.com/<username>): <Issue or PR link>
+- [@username](https://github.com/<username>): <Issue or PR link>
+- [@username](https://github.com/<username>): <Issue or PR link>
+
 ```


### PR DESCRIPTION
This closes #223. It's just a simple copy/paste outline for writing release notes, with `< >` characters where certain types of links or information should be added, and a bit of guidance about which sections should contain certain types of information.

cc @annekainicUSDS @dmethvin-gov for 👀 
cc @fatima-gov in case you'd like to link to this in the internal docs somewhere?