### PR TITLE
 Update the CheckboxWidget to support a description (Issue 243)

### DIFF
--- a/src/js/fields/DescriptionField.jsx
+++ b/src/js/fields/DescriptionField.jsx
@@ -1,27 +1,26 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 function DescriptionField(props) {
   const { description, ...rest } = props;
   if (!description) {
     return null;
   }
-  if (typeof description === "string") {
+  if (typeof description === 'string') {
     return (
       <p>
         {description}
       </p>
     );
-  } else if (typeof description === "function") {
+  } else if (typeof description === 'function') {
     const Description = description;
-    return (<Description {...rest} />);
-  } else {
-    return (
-      <div>
-        {description}
-      </div>
-    );
+    return (<Description {...rest}/>);
   }
+  return (
+    <div>
+      {description}
+    </div>
+  );
 }
 
 DescriptionField.propTypes = {

--- a/src/js/fields/DescriptionFields.jsx
+++ b/src/js/fields/DescriptionFields.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+function DescriptionField(props) {
+  const { description, ...rest } = props;
+  if (!description) {
+    return null;
+  }
+  if (typeof description === "string") {
+    return (
+      <p>
+        {description}
+      </p>
+    );
+  } else if (typeof description === "function") {
+    const Description = description;
+    return (<Description {...rest} />);
+  } else {
+    return (
+      <div>
+        {description}
+      </div>
+    );
+  }
+}
+
+DescriptionField.propTypes = {
+  description: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.element]).isRequired,
+  formContext: PropTypes.object,
+  formData: PropTypes.object,
+  options: PropTypes.object,
+};
+
+export default DescriptionField;

--- a/src/js/widgets/CheckboxWidget.jsx
+++ b/src/js/widgets/CheckboxWidget.jsx
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
+import DescriptionField from '../fields/DescriptionField';
+
 export default function CheckboxWidget({
   id,
   value,
@@ -25,6 +27,7 @@ export default function CheckboxWidget({
       <label className="schemaform-label" htmlFor={id}>
         {options.title || label}{requiredSpan}
       </label>
+      {options.description && <DescriptionField description={options.description}/>}
     </div>
   );
 }

--- a/test/js/fields/DescriptionField.unit.spec.js
+++ b/test/js/fields/DescriptionField.unit.spec.js
@@ -13,7 +13,7 @@ describe('Schemaform <DescriptionField>', () => {
     expect(tree.text()).to.equal('description');
   });
   it('should render description element', () => {
-  const GetDescription = () => (<p>description</p>);
+    const GetDescription = () => (<p>description</p>);
     const tree = SkinDeep.shallowRender(
       <DescriptionField description={GetDescription}/>
     );
@@ -21,12 +21,12 @@ describe('Schemaform <DescriptionField>', () => {
     expect(tree.dive(['GetDescription']).text()).to.equal('description');
   });
   it('should render with optional props', () => {
-    const GetDescription = ({formData}) => (<p>{formData.name}</p>);
-    const formData = {name: 'abc'};
+    const GetDescription = ({ formData }) => (<p>{ formData.name }</p>);
+    const formData = { name: 'abc' };
     const tree = SkinDeep.shallowRender(
       <DescriptionField description={GetDescription} formData={formData}/>
     );
 
     expect(tree.dive(['GetDescription']).text()).to.equal('abc');
-  }); 
+  });
 });

--- a/test/js/fields/DescriptionField.unit.spec.js
+++ b/test/js/fields/DescriptionField.unit.spec.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { expect } from 'chai';
+import SkinDeep from 'skin-deep';
+
+import DescriptionField from '../../../src/js/fields/DescriptionField';
+
+describe('Schemaform <DescriptionField>', () => {
+  it('should render description text', () => {
+    const tree = SkinDeep.shallowRender(
+      <DescriptionField description="description"/>
+    );
+
+    expect(tree.text()).to.equal('description');
+  });
+  it('should render description element', () => {
+  const GetDescription = () => (<p>description</p>);
+    const tree = SkinDeep.shallowRender(
+      <DescriptionField description={GetDescription}/>
+    );
+
+    expect(tree.dive(['GetDescription']).text()).to.equal('description');
+  });
+  it('should render with optional props', () => {
+    const GetDescription = ({formData}) => (<p>{formData.name}</p>);
+    const formData = {name: 'abc'};
+    const tree = SkinDeep.shallowRender(
+      <DescriptionField description={GetDescription} formData={formData}/>
+    );
+
+    expect(tree.dive(['GetDescription']).text()).to.equal('abc');
+  }); 
+});

--- a/test/js/widgets/CheckboxWidget.unit.spec.jsx
+++ b/test/js/widgets/CheckboxWidget.unit.spec.jsx
@@ -15,9 +15,10 @@ describe('Schemaform <CheckboxWidget>', () => {
         required
         disabled={false}
         onChange={onChange}
-        options={{ title: 'Title' }}/>
+        options={{ title: 'Title', description: 'description' }}/>
     );
     expect(tree.text()).to.include('Title');
+    expect(tree.dive(['DescriptionField']).text()).to.equal('description');
     expect(tree.subTree('input').props.checked).to.be.true;
     expect(tree.everySubTree('.form-required-span')).not.to.be.empty;
   });


### PR DESCRIPTION
These changes address #243.

In addition to updating CheckboxWidget to support a description, a description field component (DescriptionField) has been set up to manage the description logic, as there are several instances of duplicated description-related logic in FieldTemplate, ArrayField, BasicArrayField, and ObjectField.