### PR TITLE
Wrap comments in sample `formjs` code

### DIFF
--- a/docs/building-a-form/quick-start-example-formjs-file.md
+++ b/docs/building-a-form/quick-start-example-formjs-file.md
@@ -9,25 +9,34 @@ const formConfig = {
   // Prefix string to add to the path for each page.
   urlPrefix: '',
 
-  // The introduction page component. To exclude an introduction page, remove this component.
+  // The introduction page component. To exclude an introduction page, remove
+  // this component.
   introduction: IntroductionComponent,
 
-  // The confirmation page component that will render after the user successfully submits the form.
+  // The confirmation page component that will render after the user
+  // successfully submits the form.
   confirmation: ConfirmationComponent,
 
-  // The prefix for Google Analytics events that are sent for different form actions.
+  // The prefix for Google Analytics events that are sent for different form
+  // actions.
   trackingPrefix: '',
 
   // The title of the form, rendered on all pages.
   title: '',
 
-  // The subtitle of the form, usually the form number. The subtitle is rendered on all pages when there's also a title.
+  // The subtitle of the form, usually the form number. The subtitle is rendered
+  // on all pages when there's also a title.
   subTitle: '',
 
-  // Schema definitions that can be referenced on any page. These are added to each page's schema in the reducer code, so that you don't have to put all of the common fields in the definitions property in each page schema. For more information on definitions, see schema.definitions below.
+  // Schema definitions that can be referenced on any page. These are added to
+  // each page's schema in the reducer code, so that you don't have to put all
+  // of the common fields in the definitions property in each page schema. For
+  // more information on definitions, see schema.definitions below.
   defaultDefinitions: {},
 
-  // When a user begins completing a pre-filled form, this function is called after data migrations are run for pre-filled data in order to make necessary updates to the data or form schema ahead of time.
+  // When a user begins completing a pre-filled form, this function is called
+  // after data migrations are run for pre-filled data in order to make
+  // necessary updates to the data or form schema ahead of time.
   prefillTransformer: (pages, formData, metadata ) => { pages, formData, metadata },
 
   // The object that contains the configuration for each chapter.
@@ -39,14 +48,16 @@ const formConfig = {
 
       // The object that contains the pages in each chapter.
       pages: {
-        // Each property is the key for a page, and should be unique across chapters.
+        // Each property is the key for a page, and should be unique across
+        // chapters.
         pageOne: {
-            // The URL for the page.
+          // The URL for the page.
           path: 'some-path',
 
           // The title of the page that renders on the review page.
           title: '',
-          // `title` can also be a function that receives the current data as a parameter:
+          // `title` can also be a function that receives the current data as a
+          // parameter:
           title: formData => `A title for ${formData.thing}`,
 
           // Any initial data that should be set for the form.
@@ -54,8 +65,10 @@ const formConfig = {
             field1: 'Default string'
           },
 
-          // Specifies that a page will turn its schema into a page for each item in an array, such as an array of children with a page
-          // for each child. The schema/uiSchema for this type of page should be built as usual for an array field.
+          // Specifies that a page will turn its schema into a page for each
+          // item in an array, such as an array of children with a page for each
+          // child. The schema/uiSchema for this type of page should be built as
+          // usual for an array field.
           showPagePerItem: true,
           // The path to the array.
           arrayPath: 'children',
@@ -64,28 +77,36 @@ const formConfig = {
           // You must specify a path with an :index parameter.
           path: 'some-path/:index',
 
-          // The JSON schema object for the page, following the JSON Schema format.
+          // The JSON schema object for the page, following the JSON Schema
+          // format.
           schema: {
             type: 'object',
             // A schema's properties refer to definitions. For example:
-            //   "homePhone": { "$ref": "#/definitions/phone" }
-            // In the configuration file, the definition for `phone` must be added into definitions in order to be parsed correctly and added to `homePhone`.
+            // "homePhone": { "$ref": "#/definitions/phone" } In the
+            // configuration file, the definition for `phone` must be added into
+            // definitions in order to be parsed correctly and added to
+            // `homePhone`.
             definitions: {},
             properties: {
               field1: {
                 type: 'string'
               },
-              // Fields of type `string`, `boolean`, `number`, and `array` that begin with `view:` are excluded from data that's sent to
-              // the server. Instead, their children are merged into the parent object and sent to the server. Use these to exclude fields
-              // from being sent to the server, such as a question that's only used to reveal other questions, or to group related
-              // questions together to be conditionally revealed that aren't in an object in the schema.
+              // Fields of type `string`, `boolean`, `number`, and `array` that
+              // begin with `view:` are excluded from data that's sent to the
+              // server. Instead, their children are merged into the parent
+              // object and sent to the server. Use these to exclude fields from
+              // being sent to the server, such as a question that's only used
+              // to reveal other questions, or to group related questions
+              // together to be conditionally revealed that aren't in an object
+              // in the schema.
               'view:field2': {
                 type: 'string'
               },
               'view:artificialGroup': {
                 type: 'object',
                 properties: {
-                  // `view:artificialGroup` is flattened. `subField1` and `subField2` are siblings of `field1` when sent to the API.
+                  // `view:artificialGroup` is flattened. `subField1` and
+                  // `subField2` are siblings of `field1` when sent to the API.
                   subField1: {
                     type: 'string'
                   },


### PR DESCRIPTION
The inline comments on the example `form.js` doc ([seen here](https://github.com/usds/us-forms-system/blob/master/docs/building-a-form/quick-start-example-formjs-file.md)) are long and are hard to read because you need to scroll horizontally. This PR simply wraps the comments at 80 characters to aid readability. No other changes were made.

## Types of changes
- [x] Documentation update
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I've reviewed the [guidelines for contributing to this repository](../../CONTRIBUTING.md#how-to-contribute-to-us-forms-system).
- [x] I've checked style and lint with `npm run lint`.
- [x] I built the production version with `npm run build`.
- [ ] I added tests to verify a bug fix or new functionality.
- [x] All tests pass locally with `npm test`.
- [x] My change requires a change to the documentation, and I've updated the documentation accordingly.
