### PR TITLE
Use mocha's --require rather than the deprecated --compilers

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:md-full": "git ls-files '*.md' | xargs -I FILE npx markdown-link-check -q FILE",
     "lint:js": "eslint --quiet --ext .js --ext .jsx .",
     "lint:sass": "sass-lint -c test/config/sass-lint.yaml --verbose",
-    "test": "BABEL_ENV=test mocha --require test/config/unit-test-setup.js --require test/config/enzyme-setup.jsx --compilers js:babel-core/register './test/**/*.spec.js?(x)' "
+    "test": "BABEL_ENV=test mocha --require babel-core/register --require test/config/unit-test-setup.js --require test/config/enzyme-setup.jsx './test/**/*.spec.js?(x)' "
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
See https://github.com/mochajs/mocha/wiki/compilers-deprecation

We'll need to change this again when we switch to Babel 7, the page above explains how.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've reviewed the [guidelines for contributing to this repository](../CONTRIBUTING.md#how-to-contribute-to-us-forms-system).
- [x] I've checked style and lint with `npm run lint`.
- [x] I built the production version with `npm run build`.
- [x] I added tests to verify a bug fix or new functionality.
- [x] All tests pass locally with `npm test`.
- [ ] ~~My change requires a change to the documentation, and I've updated the documentation accordingly.~~
