### PR TITLE
[For discussion] Create build artifacts in separate repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,28 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/repo
-      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
-      - run: npm publish
+      - run: |
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc;
+          npm publish
+
+  artifacts:
+    <<: *common
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - add_ssh_keys:
+          fingerprints:
+            - "57:4b:f6:31:3f:dc:80:fd:ee:b4:e4:ba:0f:98:20:22"
+      - run: |
+          cd ~/repo
+          git config user.email "USFS-bot@usds.gov"
+          git config user.name "USFS Bot"
+          echo -e "\nHost github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+          grep -v lib/ .gitignore >.gitignore-new
+          mv .gitignore-new .gitignore
+          git add lib/
+          git commit -m "CircleCI $CIRCLE_BRANCH -- add built files in lib/"
+          git push --force git@github.com:dmethvin-gov/usfs-builds.git $CIRCLE_BRANCH
 
 workflows:
   version: 2
@@ -42,3 +62,6 @@ workflows:
           filters:
             branches:
               only: production
+      - artifacts:
+          requires:
+            - build


### PR DESCRIPTION
Since we're not storing the build artifacts anymore, it is not quite as convenient to reference a specific branch, or commit for testing (not production!) with an external app. This PR is a proof-of-concept for one way to store these builds using a second Github repo. 

The basic approach is to have CircleCI take the build artifacts generated in `lib/` and commit them to a new repo. Then it's possible to reference built files in that repo using either a commit hash or a branch name. I don't have admin access to create the `usds/usfs-builds` repo so I created one under my own account, along with SSH keys that are locked down to just that new repo.  [Here's what a commit looks like.](https://github.com/dmethvin-gov/usfs-builds/commits/builds--218)

One other thing we might consider doing in this step is actually running the tests with the built files. None of our tests are currently running with the built files, they are being compiled via mocha during testing and then discarded. Although you could argue that it *should* compile to the same result it would be reassuring if we actually tested with the files we plan to distribute.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've reviewed the [guidelines for contributing to this repository](../CONTRIBUTING.md#how-to-contribute-to-us-forms-system).
- [ ] I've checked style and lint with `npm run lint`.
- [ ] I built the production version with `npm run build`.
- [ ] I added tests to verify a bug fix or new functionality.
- [ ] All tests pass locally with `npm test`.
- [ ] My change requires a change to the documentation, and I've updated the documentation accordingly.
