### PR TITLE
Update dependencies to remove warnings when using React 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/runtime": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+      "requires": {
+        "regenerator-runtime": "0.12.1"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
     "@department-of-veterans-affairs/react-jsonschema-form": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@department-of-veterans-affairs/react-jsonschema-form/-/react-jsonschema-form-1.0.0.tgz",
@@ -7976,6 +7991,11 @@
         "json-stringify-pretty-compact": "1.2.0"
       }
     },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "react-redux": {
       "version": "4.4.8",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.8.tgz",
@@ -8178,14 +8198,23 @@
       }
     },
     "recompose": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.21.2.tgz",
-      "integrity": "sha1-/z+9sjl7HHfEfUUb4qY7kpXURoE=",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
+      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
       "requires": {
+        "@babel/runtime": "7.2.0",
         "change-emitter": "0.1.6",
         "fbjs": "0.8.16",
-        "hoist-non-react-statics": "1.2.0",
+        "hoist-non-react-statics": "2.5.5",
+        "react-lifecycles-compat": "3.0.4",
         "symbol-observable": "1.2.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
       }
     },
     "redent": {

--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
     "uswds": "^1.6.3"
   },
   "dependencies": {
-    "classnames": "^2.2.5",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
+    "classnames": "^2.2.5",
     "downshift": "^1.22.5",
     "fast-levenshtein": "^2.0.6",
     "history": "3",
@@ -95,7 +95,7 @@
     "react-router": "3",
     "react-scroll": "^1.7.9",
     "react-transition-group": "^1.1.2",
-    "recompose": "^0.21.2",
+    "recompose": "^0.30.0",
     "redux": "^3.5.2",
     "reselect": "^2.5.4"
   }

--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
     "vets-json-schema": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git"
   },
   "peerDependencies": {
-    "react": "^15.5.4",
-    "react-dom": "^15.6.2",
-    "uswds": "^1.6.3"
+    "react": "^15.5.4||^16.7.0",
+    "react-dom": "^15.6.2||^16.7.0",
+    "uswds": "^1.4.2"
   },
   "dependencies": {
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",

--- a/test/js/widgets/SelectWidget.unit.spec.jsx
+++ b/test/js/widgets/SelectWidget.unit.spec.jsx
@@ -20,7 +20,7 @@ describe('Schemaform <SelectWidget>', () => {
         id="testing"
         onChange={onChange}
         options={{ enumOptions }}/>
-    );
+    ).dive(['SelectWidget']);
 
     expect(tree.everySubTree('option').length).to.equal(2);
   });
@@ -41,7 +41,7 @@ describe('Schemaform <SelectWidget>', () => {
         id="testing"
         onChange={onChange}
         options={{ enumOptions, labels }}/>
-    );
+    ).dive(['SelectWidget']);
 
     expect(tree.everySubTree('option')[1].text()).to.equal('Other');
   });
@@ -59,7 +59,7 @@ describe('Schemaform <SelectWidget>', () => {
         id="testing"
         onChange={onChange}
         options={{ enumOptions }}/>
-    );
+    ).dive(['SelectWidget']);
 
     tree.subTree('select').props.onChange({
       target: {
@@ -88,7 +88,7 @@ describe('Schemaform <SelectWidget>', () => {
         id="testing"
         onChange={onChange}
         options={{ enumOptions }}/>
-    );
+    ).dive(['SelectWidget']);
 
     tree.subTree('select').props.onChange({
       target: {
@@ -111,7 +111,7 @@ describe('Schemaform <SelectWidget>', () => {
         id="testing"
         onChange={onChange}
         options={{ enumOptions }}/>
-    );
+    ).dive(['SelectWidget']);
 
     tree.subTree('select').props.onChange({
       target: {
@@ -134,7 +134,7 @@ describe('Schemaform <SelectWidget>', () => {
         id="testing"
         onBlur={onBlur}
         options={{ enumOptions }}/>
-    );
+    ).dive(['SelectWidget']);
 
     tree.subTree('select').props.onBlur({
       target: {
@@ -159,7 +159,7 @@ describe('Schemaform <SelectWidget>', () => {
         id="testing"
         onChange={onChange}
         options={{ enumOptions }}/>
-    );
+    ).dive(['SelectWidget']);
 
     expect(tree.everySubTree('option').length).to.equal(1);
   });


### PR DESCRIPTION
On VA.gov we're updating to React 16 and USFS has some peer dependency rules that cause some warnings for us when upgrading. There's also one issue with a direct dependency, recompose, so that library is updated to the latest version.

So far in our VA.gov testing, our forms work without specific changes for React 16.

The recompose update is not a major version update, but I did come across a break change in the tests, in https://github.com/acdlite/recompose/releases/tag/v0.25.0. I made some test updates for that change (though I'm not clear on exactly why their change needed this particular change in the tests).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've reviewed the [guidelines for contributing to this repository](../CONTRIBUTING.md#how-to-contribute-to-us-forms-system).
- [x] I've checked style and lint with `npm run lint`.
- [ ] I built the production version with `npm run build`.
- [ ] I added tests to verify a bug fix or new functionality.
- [x] All tests pass locally with `npm test`.
- [ ] My change requires a change to the documentation, and I've updated the documentation accordingly.
