### PR TITLE
Update react-redux to fix security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5357,11 +5357,6 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
-    "hoist-non-react-statics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-      "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
-    },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
@@ -7991,22 +7986,38 @@
         "json-stringify-pretty-compact": "1.2.0"
       }
     },
+    "react-is": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.1.tgz",
+      "integrity": "sha512-ioMCzVDWvCvKD8eeT+iukyWrBGrA3DiFYkXfBsVYIRdaREZuBjENG+KjrikavCLasozqRWTwFUagU/O4vPpRMA=="
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-redux": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-4.4.8.tgz",
-      "integrity": "sha1-57wd0QDotk6WrIIS2xEyObni4I8=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
+      "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
       "requires": {
-        "create-react-class": "15.6.3",
-        "hoist-non-react-statics": "1.2.0",
+        "@babel/runtime": "7.2.0",
+        "hoist-non-react-statics": "3.3.0",
         "invariant": "2.2.4",
-        "lodash": "4.17.10",
         "loose-envify": "1.3.1",
-        "prop-types": "15.6.1"
+        "prop-types": "15.6.1",
+        "react-is": "16.8.1",
+        "react-lifecycles-compat": "3.0.4"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "requires": {
+            "react-is": "16.8.1"
+          }
+        }
       }
     },
     "react-router": {
@@ -10109,10 +10120,6 @@
         "core-util-is": "1.0.2",
         "extsprintf": "1.3.0"
       }
-    },
-    "vets-json-schema": {
-      "version": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git#3bd461ead9c52d12f1e496e8c7f68faa064320df",
-      "dev": true
     },
     "vm-browserify": {
       "version": "0.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10121,6 +10121,10 @@
         "extsprintf": "1.3.0"
       }
     },
+    "vets-json-schema": {
+      "version": "git+https://github.com/department-of-veterans-affairs/vets-json-schema.git#811b7c3f23bd49d166c302326b80cce2b3789595",
+      "dev": true
+    },
     "vm-browserify": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "history": "3",
     "moment": "^2.15.1",
     "raven-js": "^3.12.1",
-    "react-redux": "4.4.8",
+    "react-redux": "^5.1.1",
     "react-router": "3",
     "react-scroll": "^1.7.9",
     "react-transition-group": "^1.1.2",


### PR DESCRIPTION
<!--- Write a general summary of your changes in the Title field above -->

There's a new lodash security advisory: https://www.npmjs.com/advisories/782. The lodash version used directly here is unaffected, but react-redux uses an older version. This updates react-redux to v5, which has no breaking changes and removes the lodash dependency. There's a v6, but it has more changes and I wanted to get this out quickly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've reviewed the [guidelines for contributing to this repository](../CONTRIBUTING.md#how-to-contribute-to-us-forms-system).
- [x] I've checked style and lint with `npm run lint`.
- [ ] I built the production version with `npm run build`.
- [ ] I added tests to verify a bug fix or new functionality.
- [x] All tests pass locally with `npm test`.
- [ ] My change requires a change to the documentation, and I've updated the documentation accordingly.
